### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,30 +6,30 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HPRGB			KEYWORD1
+HPRGB	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin			KEYWORD2
-getCurrent		KEYWORD2
-setCurrent		KEYWORD2
-getFreq			KEYWORD2
-setFreq			KEYWORD2
+begin	KEYWORD2
+getCurrent	KEYWORD2
+setCurrent	KEYWORD2
+getFreq	KEYWORD2
+setFreq	KEYWORD2
 setFreqAndCurrent	KEYWORD2
-eepromWrite		KEYWORD2
-getValue		KEYWORD2
-goToRGB			KEYWORD2
-goToRGBHI		KEYWORD2
-goToRGB12		KEYWORD2
-goToHSB			KEYWORD2
-goToHSB10		KEYWORD2
-fadeToHSB		KEYWORD2
+eepromWrite	KEYWORD2
+getValue	KEYWORD2
+goToRGB	KEYWORD2
+goToRGBHI	KEYWORD2
+goToRGB12	KEYWORD2
+goToHSB	KEYWORD2
+goToHSB10	KEYWORD2
+fadeToHSB	KEYWORD2
 setPWMFrequency	KEYWORD2
-getIntTemp		KEYWORD2
-getIntTempF		KEYWORD2
-getExtTemp		KEYWORD2
-getExtTempF		KEYWORD2
+getIntTemp	KEYWORD2
+getIntTempF	KEYWORD2
+getExtTemp	KEYWORD2
+getExtTempF	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords